### PR TITLE
The Congress API docs use HTTPS

### DIFF
--- a/D3_Congress/README.md
+++ b/D3_Congress/README.md
@@ -5,7 +5,7 @@ Polarized Congress
  
 Using the **Sunlight Foundation Congress API**
 
-<http://sunlightlabs.github.io/congress/>
+<https://sunlightlabs.github.io/congress/>
 
 as well as **D3.js**
 


### PR DESCRIPTION
It redirects to `https://` if you visit the insecure version.
